### PR TITLE
More revisions to Github actions for test and build with pyproject.toml

### DIFF
--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -36,12 +36,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Ensure tags are fetched for versioning
-      - name: Setup Python ${{ matrix.python-version }} with Conda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          channels: conda-forge,defaults
-          channel-priority: true
 
       - name: Install llvm on Macos
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -57,18 +57,19 @@ jobs:
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           architecture: x64
-      - name: Set MSVC related env variables
+      - name: Set Windows compiler environment variables
         if: startsWith(matrix.os, 'windows')
         shell: bash -l {0}
         run: |
-          MSVC_BIN="$VCToolsInstallDir\bin\Hostx64\x64"
-          echo "Setting MSVC_BIN env. Directory contents:"
-          ls "$MSVC_BIN"
-          echo "CC=$MSVC_BIN\cl.exe" >> $GITHUB_ENV
-          echo "CC_LD=$MSVC_BIN\link.exe" >> $GITHUB_ENV
-          echo "What would Windows find without the full paths?"
-          where cl
-          where link
+          echo "Getting full path to cl.exe:"
+          CL_EXE=$(where cl | head -n 1)
+          echo found cl.exe "$CL_EXE"
+          echo "CC=$CL_EXE" >> $GITHUB_ENV
+
+          echo "Getting path to link.exe in same dir"
+          LINK_EXE=$(dirname "$CL_EXE")\\link.exe
+          echo "$LINK_EXE"
+          echo "CC_LD=$LINK_EXE" >> $GITHUB_ENV
 
       - name: Update Python pip, build, wheel, and twine
         shell: bash -l {0}

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -57,10 +57,14 @@ jobs:
         uses: bus1/cabuild/action/msdevshell@v1
         with:
           architecture: x64
-      - shell: bash -l {0}
+      - name: Set MSVC related env variables
+        if: startsWith(matrix.os, 'windows')
+        shell: bash -l {0}
         env:
           MSVC_BIN: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\bin\HostX64\x64'
         run: |
+          echo "Setting MSVC_BIN env. Directory contents:"
+          ls $MSVC_BIN
           echo "CC=msvc" >> $GITHUB_ENV
           echo "CC_LD=link" >> $GITHUB_ENV
 

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -52,24 +52,24 @@ jobs:
           echo CC="${LLVM_DIR}/bin/clang" >> $GITHUB_ENV
           echo LDFLAGS="-L${LLVM_DIR}/lib $LDFLAGS" >> $GITHUB_ENV
           echo CPPFLAGS="-I${LLVM_DIR}/include $CPPFLAGS" >> $GITHUB_ENV
-      - name: Setup MSVC env on Windows
-        if: startsWith(matrix.os, 'windows')
-        uses: bus1/cabuild/action/msdevshell@v1
-        with:
-          architecture: x64
-      - name: Set Windows compiler environment variables
+
+      - name: Windows - find MSVC and set environment variables
         if: startsWith(matrix.os, 'windows')
         shell: bash -l {0}
+        env:
+          MSVC_PREFIX: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC'
         run: |
-          echo "Getting full path to cl.exe:"
-          CL_EXE=$(where cl | head -n 1)
-          echo found cl.exe "$CL_EXE"
-          echo "CC=$CL_EXE" >> $GITHUB_ENV
+          echo "Available MSVC installations:"
+          ls "$MSVC_PREFIX"
 
-          echo "Getting path to link.exe in same dir"
-          LINK_EXE=$(dirname "$CL_EXE")\\link.exe
-          echo "$LINK_EXE"
-          echo "CC_LD=$LINK_EXE" >> $GITHUB_ENV
+          MSVC_BIN=$(ls "$MSVC_PREFIX" | tail -n 1)\\bin\\HostX64\\x64
+          CC="$MSVC_PREFIX\\$MSVC_BIN\\cl.exe"
+          echo "CC: $CC"
+          echo "CC=$CC" >> $GITHUB_ENV
+
+          CC_LD="$MSVC_PREFIX\\$MSVC_BIN\\link.exe"
+          echo "CC_LD: $CC_LD"
+          echo "CC_LD=$CC_LD" >> $GITHUB_ENV
 
       - name: Update Python pip, build, wheel, and twine
         shell: bash -l {0}

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -63,9 +63,12 @@ jobs:
         run: |
           MSVC_BIN="$VCToolsInstallDir\bin\Hostx64\x64"
           echo "Setting MSVC_BIN env. Directory contents:"
-          ls $MSVC_BIN
+          ls "$MSVC_BIN"
           echo "CC=$MSVC_BIN\cl.exe" >> $GITHUB_ENV
           echo "CC_LD=$MSVC_BIN\link.exe" >> $GITHUB_ENV
+          echo "What would Windows find without the full paths?"
+          where cl
+          where link
 
       - name: Update Python pip, build, wheel, and twine
         shell: bash -l {0}

--- a/.github/workflows/build_upload_pypi_wheels.yml
+++ b/.github/workflows/build_upload_pypi_wheels.yml
@@ -60,13 +60,12 @@ jobs:
       - name: Set MSVC related env variables
         if: startsWith(matrix.os, 'windows')
         shell: bash -l {0}
-        env:
-          MSVC_BIN: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\bin\HostX64\x64'
         run: |
+          MSVC_BIN="$VCToolsInstallDir\bin\Hostx64\x64"
           echo "Setting MSVC_BIN env. Directory contents:"
           ls $MSVC_BIN
-          echo "CC=msvc" >> $GITHUB_ENV
-          echo "CC_LD=link" >> $GITHUB_ENV
+          echo "CC=$MSVC_BIN\cl.exe" >> $GITHUB_ENV
+          echo "CC_LD=$MSVC_BIN\link.exe" >> $GITHUB_ENV
 
       - name: Update Python pip, build, wheel, and twine
         shell: bash -l {0}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,25 +42,43 @@ jobs:
           echo LDFLAGS="-L${LLVM_DIR}/lib $LDFLAGS" >> $GITHUB_ENV
           echo CPPFLAGS="-I${LLVM_DIR}/include $CPPFLAGS" >> $GITHUB_ENV
 
-      - name: Setup MSVC env on Windows
-        if: startsWith(matrix.os, 'windows')
-        uses: bus1/cabuild/action/msdevshell@v1
-        with:
-          architecture: x64
-
-      - name: Set Windows compiler environment variables
+      - name: Explore MSVC env before setup
         if: startsWith(matrix.os, 'windows')
         shell: bash -l {0}
-        run: |
-          echo "Getting full path to cl.exe:"
-          CL_EXE=$(where cl | head -n 1)
-          echo found cl.exe "$CL_EXE"
-          echo "CC=$CL_EXE" >> $GITHUB_ENV
+        run:
+          #   MSVC_BIN: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\bin\HostX64\x64'
 
-          echo "Getting path to link.exe in same dir"
-          LINK_EXE=$(dirname "$CL_EXE")\\link.exe
-          echo "$LINK_EXE"
-          echo "CC_LD=$LINK_EXE" >> $GITHUB_ENV
+          #   echo "CC=${MSVC_BIN}\cl.exe" >> $GITHUB_ENV
+          #   echo "CC_LD=${MSVC_BIN}\link.exe" >> $GITHUB_ENV
+
+          ls 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\'
+
+          MSVC_BIN=$(ls 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\' | head -n 1)\\bin\\HostX64\\x64
+          echo $MSVC_BIN
+          echo "CC=$MSVC_BIN\\cl.exe" >> $GITHUB_ENV
+          echo "CC_LD=$MSVC_BIN\\link.exe" >> $GITHUB_ENV
+
+          echo $GITHUB_ENV
+
+      # - name: Setup MSVC env on Windows
+      #   if: startsWith(matrix.os, 'windows')
+      #   uses: bus1/cabuild/action/msdevshell@v1
+      #   with:
+      #     architecture: x64
+
+      # - name: Set Windows compiler environment variables
+      #   if: startsWith(matrix.os, 'windows')
+      #   shell: bash -l {0}
+      #   run: |
+      #     echo "Getting full path to cl.exe:"
+      #     CL_EXE=$(where cl | head -n 1)
+      #     echo found cl.exe "$CL_EXE"
+      #     echo "CC=$CL_EXE" >> $GITHUB_ENV
+
+      #     echo "Getting path to link.exe in same dir"
+      #     LINK_EXE=$(dirname "$CL_EXE")\\link.exe
+      #     echo "$LINK_EXE"
+      #     echo "CC_LD=$LINK_EXE" >> $GITHUB_ENV
 
       - name: Update pip and install dependencies
         shell: bash -l {0}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-          channels: conda-forge,defaults
-          channel-priority: true
-
+          python-version: |
+              3.10
+              3.11
+              3.12
       - name: Install llvm on MacOS
         if: startsWith(matrix.os, 'macos')
         shell: bash -l {0}
@@ -101,11 +101,9 @@ jobs:
     if: success() || failure()
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-          channels: conda-forge,defaults
-          channel-priority: true
+          python-version: 3.10
       - name: Update pip and install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,25 +42,25 @@ jobs:
           echo LDFLAGS="-L${LLVM_DIR}/lib $LDFLAGS" >> $GITHUB_ENV
           echo CPPFLAGS="-I${LLVM_DIR}/include $CPPFLAGS" >> $GITHUB_ENV
 
-      # - name: Setup MSVC env on Windows
-      #   if: startsWith(matrix.os, 'windows')
-      #   uses: bus1/cabuild/action/msdevshell@v1
-      #   with:
-      #     architecture: x64
-      # - name: Setup MSVC env on Windows
-      #   if: startsWith(matrix.os, 'windows')
-      #   shell: bash -l {0}
-      #   run: |
-      #     echo "CC=${VCToolsInstallDir}bin\HostX64\cl.exe" >> $GITHUB_ENV
-      #     echo "CC_LD=${VCToolsInstallDir}bin\HostX64\link.exe" >> $GITHUB_ENV
       - name: Setup MSVC env on Windows
         if: startsWith(matrix.os, 'windows')
+        uses: bus1/cabuild/action/msdevshell@v1
+        with:
+          architecture: x64
+
+      - name: Set Windows compiler environment variables
+        if: startsWith(matrix.os, 'windows')
         shell: bash -l {0}
-        env:
-          MSVC_BIN: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\bin\HostX64\x64'
         run: |
-          echo "CC=${MSVC_BIN}\cl.exe" >> $GITHUB_ENV
-          echo "CC_LD=${MSVC_BIN}\link.exe" >> $GITHUB_ENV
+          echo "Getting full path to cl.exe:"
+          CL_EXE=$(where cl | head -n 1)
+          echo found cl.exe "$CL_EXE"
+          echo "CC=$CL_EXE" >> $GITHUB_ENV
+
+          echo "Getting path to link.exe in same dir"
+          LINK_EXE=$(dirname "$CL_EXE")\\link.exe
+          echo "$LINK_EXE"
+          echo "CC_LD=$LINK_EXE" >> $GITHUB_ENV
 
       - name: Update pip and install dependencies
         shell: bash -l {0}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -42,43 +42,23 @@ jobs:
           echo LDFLAGS="-L${LLVM_DIR}/lib $LDFLAGS" >> $GITHUB_ENV
           echo CPPFLAGS="-I${LLVM_DIR}/include $CPPFLAGS" >> $GITHUB_ENV
 
-      - name: Explore MSVC env before setup
+      - name: Windows - find MSVC and set environment variables
         if: startsWith(matrix.os, 'windows')
         shell: bash -l {0}
-        run:
-          #   MSVC_BIN: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\bin\HostX64\x64'
+        env:
+          MSVC_PREFIX: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\'
+        run: |
+          echo "Available MSVC installations:"
+          ls "$MSVC_PREFIX"
 
-          #   echo "CC=${MSVC_BIN}\cl.exe" >> $GITHUB_ENV
-          #   echo "CC_LD=${MSVC_BIN}\link.exe" >> $GITHUB_ENV
+          MSVC_BIN=$(ls "$MSVC_PREFIX" | tail -n 1)\\bin\\HostX64\\x64
+          CC="$MSVC_PREFIX\\$MSVC_BIN\\cl.exe"
+          echo "CC: $CC"
+          echo "CC=$CC" >> $GITHUB_ENV
 
-          ls 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\'
-
-          MSVC_BIN=$(ls 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\' | head -n 1)\\bin\\HostX64\\x64
-          echo $MSVC_BIN
-          echo "CC=$MSVC_BIN\\cl.exe" >> $GITHUB_ENV
-          echo "CC_LD=$MSVC_BIN\\link.exe" >> $GITHUB_ENV
-
-          echo $GITHUB_ENV
-
-      # - name: Setup MSVC env on Windows
-      #   if: startsWith(matrix.os, 'windows')
-      #   uses: bus1/cabuild/action/msdevshell@v1
-      #   with:
-      #     architecture: x64
-
-      # - name: Set Windows compiler environment variables
-      #   if: startsWith(matrix.os, 'windows')
-      #   shell: bash -l {0}
-      #   run: |
-      #     echo "Getting full path to cl.exe:"
-      #     CL_EXE=$(where cl | head -n 1)
-      #     echo found cl.exe "$CL_EXE"
-      #     echo "CC=$CL_EXE" >> $GITHUB_ENV
-
-      #     echo "Getting path to link.exe in same dir"
-      #     LINK_EXE=$(dirname "$CL_EXE")\\link.exe
-      #     echo "$LINK_EXE"
-      #     echo "CC_LD=$LINK_EXE" >> $GITHUB_ENV
+          CC_LD="$MSVC_PREFIX\\$MSVC_BIN\\link.exe"
+          echo "CC_LD: $CC_LD"
+          echo "CC_LD=$CC_LD" >> $GITHUB_ENV
 
       - name: Update pip and install dependencies
         shell: bash -l {0}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -46,7 +46,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         shell: bash -l {0}
         env:
-          MSVC_PREFIX: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\'
+          MSVC_PREFIX: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC'
         run: |
           echo "Available MSVC installations:"
           ls "$MSVC_PREFIX"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-requires = tox-conda
 # The python environments to run the tests in
 envlist = py310,py311,py312,py310-{base,matplotlib,phonopy_reader,brille,all},py310-minrequirements-linux
 # Skip the execution of setup.py as we do it with the correct arg in commands_pre below


### PR DESCRIPTION
### Initial motivation

setup-python action now supports installing multiple python versions, so tox-conda doesn't seem to be necessary any more.

Perhaps this will make the compiler environment easier to reason about?

### Actual progress

- Replaced miniconda setup with setup-python, removed tox-conda from tox.ini
- Removed hard-coded full paths to MSVC compilers, replaced with search for existing directories. This is _more_ resilient against version changes, but may need adapting when, e.g., runners move away from the whole "2022" platform.
- Removed the bus1/cabuild/action/msdevshell@v1 action; CC and CC_LD seem to be all the variables we need.